### PR TITLE
4 create teams class

### DIFF
--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,0 +1,15 @@
+class Team
+  attr_reader :team_id,
+              :franchise_id,
+              :team_name,
+              :abbreviation,
+              :link
+              
+  def initialize(team)
+    @team_id = team[:team_id]
+    @franchise_id = team[:franchiseId]
+    @team_name = team[:teamName]
+    @abbreviation = team[:abbreviation]
+    @link = team[:link]
+  end
+end

--- a/spec/team_spec.rb
+++ b/spec/team_spec.rb
@@ -1,0 +1,29 @@
+require 'rspec'
+require './lib/game'
+require './lib/team'
+
+RSpec.describe Team do
+  before(:each) do
+    hash = {
+      :team_id => 1,
+      :franchiseId => 23,
+      :teamName => "Atlanta United"
+      :abbreviation => "ATL"
+      :link => "/api/v1/teams/1"
+    } #are the above strings actually strings in the csv? arrays right?
+    #can we fix the camel case?
+    @team = Team.new(hash)
+  end
+
+  it 'exists' do
+    expect(@team).to be_a(Team)
+  end
+
+  it 'the team has attributes' do
+    expect(@team.team_id).to eq(1)
+    expect(@team.franchiseId).to eq(23)
+    expect(@team.teamName).to eq("Atlanta United")
+    expect(@team.abbreviation).to eq("ATL")
+    expect(@team.link).to eq("/api/v1/teams/1")
+  end
+end

--- a/spec/team_spec.rb
+++ b/spec/team_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Team do
     hash = {
       :team_id => 1,
       :franchiseId => 23,
-      :teamName => "Atlanta United"
-      :abbreviation => "ATL"
+      :teamName => "Atlanta United",
+      :abbreviation => "ATL",
       :link => "/api/v1/teams/1"
     } #are the above strings actually strings in the csv? arrays right?
     #can we fix the camel case?
@@ -21,8 +21,8 @@ RSpec.describe Team do
 
   it 'the team has attributes' do
     expect(@team.team_id).to eq(1)
-    expect(@team.franchiseId).to eq(23)
-    expect(@team.teamName).to eq("Atlanta United")
+    expect(@team.franchise_id).to eq(23)
+    expect(@team.team_name).to eq("Atlanta United")
     expect(@team.abbreviation).to eq("ATL")
     expect(@team.link).to eq("/api/v1/teams/1")
   end


### PR DESCRIPTION
This pull request contains the Team class initialize method with attributes and their corresponding tests.

Note the difference between how headers are displayed in the CSV and spec, versus the defined instance variables. One is in camel case. Do we need to stick with one, or does it matter once it's assigned to an instance variable?