### PR TITLE
34 fewest and most tackles

### DIFF
--- a/lib/season_statistics.rb
+++ b/lib/season_statistics.rb
@@ -66,7 +66,7 @@ class SeasonStatistics < Stats
   end
 
   def accuracy(goals, shots)
-    goals.fdiv(shots).round(2)
+    goals.fdiv(shots).round(5)
   end
 
   def team_by_id(id)

--- a/lib/season_statistics.rb
+++ b/lib/season_statistics.rb
@@ -27,9 +27,31 @@ class SeasonStatistics < Stats
     team_by_id(team.first)
   end
 
+  def most_tackles(season)
+    games_in_season = filter_game_teams_by_season(season)
+    games_by_team = games_in_season.group_by{|game_team| game_team.team_id}
+    games_by_team = tackles_by_team(games_by_team)
+    team = games_by_team.max_by{|team, tackles| tackles}
+    team_by_id(team.first)
+  end
+
+  def fewest_tackles(season)
+    games_in_season = filter_game_teams_by_season(season)
+    games_by_team = games_in_season.group_by{|game_team| game_team.team_id}
+    games_by_team = tackles_by_team(games_by_team)
+    team = games_by_team.min_by{|team, tackles| tackles}
+    team_by_id(team.first)
+  end
+
   def filter_game_teams_by_season(season)
     year = season[0,4]
     @game_teams.select{|game| game.game_id.start_with?(year)}
+  end
+
+  def tackles_by_team(hash)
+    hash.transform_values do |games| 
+      games.sum{|game| game.tackles}
+    end
   end
 
   def goals_and_shots_by_team(hash)

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -37,5 +37,13 @@ class StatTracker
   def least_accurate_team(season)
     @season.least_accurate_team(season)
   end
+
+  def most_tackles(season)
+    @season.most_tackles(season)
+  end
+
+  def fewest_tackles(season)
+    @season.fewest_tackles(season)
+  end
 end
 

--- a/spec/season_statistics_spec.rb
+++ b/spec/season_statistics_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe SeasonStatistics do
     end
   end
 
-  describe '#least_tackles' do
-    xit 'returns the team with the least tackles in given season' do
-      expect(@season_stats.most_tackles('20122013')).to eq('FC Dallas')
-      expect(@season_stats.most_tackles('20142015')).to eq('New England Revolution')
+  describe '#fewest_tackles' do
+    it 'returns the team with the least tackles in given season' do
+      expect(@season_stats.fewest_tackles('20122013')).to eq('FC Dallas')
+      expect(@season_stats.fewest_tackles('20142015')).to eq('New England Revolution')
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe SeasonStatistics do
       mock_game_1 = double()
       mock_game_2 = double()
       given_hash = {team: [mock_game_1], team2: [mock_game_2]}
-      expected_hash = {team: [20], team2: [30]}
+      expected_hash = {team: 20, team2: 30}
 
       allow(mock_game_1).to receive(:tackles).and_return(20)
       allow(mock_game_2).to receive(:tackles).and_return(30)

--- a/spec/season_statistics_spec.rb
+++ b/spec/season_statistics_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe SeasonStatistics do
     end
   end
 
+  describe '#most_tackles' do
+    it 'returns the team with the most tackles in given season' do
+      expect(@season_stats.most_tackles('20122013')).to eq('FC Dallas')
+      expect(@season_stats.most_tackles('20142015')).to eq('Orlando Pride')
+    end
+  end
+
+  describe '#least_tackles' do
+    it 'returns the team with the least tackles in given season' do
+      expect(@season_stats.most_tackles('20122013')).to eq('Houston Dynamo')
+      expect(@season_stats.most_tackles('20142015')).to eq('Chicago Fire')
+
+    end
+  end
+
   describe '#filter_game_teams_by_season' do
     it 'returns list of game teams that took place in given season' do
       filtered_games = @season_stats.filter_game_teams_by_season('20122013')

--- a/spec/season_statistics_spec.rb
+++ b/spec/season_statistics_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe SeasonStatistics do
 
   describe '#accuracy' do
     it 'returns goals divided by number of shots' do
-      expect(@season_stats.accuracy(5,10)).to eq 0.50
-      expect(@season_stats.accuracy(3, 9)).to eq 0.33
+      expect(@season_stats.accuracy(5,10)).to eq 0.50000
+      expect(@season_stats.accuracy(3, 9)).to eq 0.33333
     end
   end
 

--- a/spec/season_statistics_spec.rb
+++ b/spec/season_statistics_spec.rb
@@ -51,16 +51,15 @@ RSpec.describe SeasonStatistics do
 
   describe '#most_tackles' do
     it 'returns the team with the most tackles in given season' do
-      expect(@season_stats.most_tackles('20122013')).to eq('FC Dallas')
+      expect(@season_stats.most_tackles('20122013')).to eq('Houston Dynamo')
       expect(@season_stats.most_tackles('20142015')).to eq('Orlando Pride')
     end
   end
 
   describe '#least_tackles' do
-    it 'returns the team with the least tackles in given season' do
-      expect(@season_stats.most_tackles('20122013')).to eq('Houston Dynamo')
-      expect(@season_stats.most_tackles('20142015')).to eq('Chicago Fire')
-
+    xit 'returns the team with the least tackles in given season' do
+      expect(@season_stats.most_tackles('20122013')).to eq('FC Dallas')
+      expect(@season_stats.most_tackles('20142015')).to eq('New England Revolution')
     end
   end
 
@@ -68,6 +67,20 @@ RSpec.describe SeasonStatistics do
     it 'returns list of game teams that took place in given season' do
       filtered_games = @season_stats.filter_game_teams_by_season('20122013')
       expect(filtered_games.all?{|game| game.game_id.start_with?('2012')}).to be true
+    end
+  end
+
+  describe '#tackles_by_team' do
+    it 'returns number of tackles by team' do
+      mock_game_1 = double()
+      mock_game_2 = double()
+      given_hash = {team: [mock_game_1], team2: [mock_game_2]}
+      expected_hash = {team: [20], team2: [30]}
+
+      allow(mock_game_1).to receive(:tackles).and_return(20)
+      allow(mock_game_2).to receive(:tackles).and_return(30)
+
+      expect(@season_stats.tackles_by_team(given_hash)).to eq(expected_hash)
     end
   end
 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -65,4 +65,18 @@ end
       expect(@stat_tracker.least_accurate_team('20142015')).to eq('New England Revolution')
     end
   end
+
+  describe '#most_tackles' do
+    it 'returns the team with the most tackles in given season' do
+      expect(@stat_tracker.most_tackles('20122013')).to eq('FC Cincinnati')
+      expect(@stat_tracker.most_tackles('20142015')).to eq('Seattle Sounders FC')
+    end
+  end
+
+  describe '#fewest_tackles' do
+    it 'returns the team with the least tackles in given season' do
+      expect(@stat_tracker.fewest_tackles('20122013')).to eq('Atlanta United')
+      expect(@stat_tracker.fewest_tackles('20142015')).to eq('Orlando City SC')
+    end
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -55,14 +55,14 @@ end
   describe '#most_accurate_team' do
     it 'returns the team with the best ratio of shots to goals' do
       expect(@stat_tracker.most_accurate_team('20122013')).to eq('DC United')
-      expect(@stat_tracker.most_accurate_team('20142015')).to eq('Orlando Pride')
+      expect(@stat_tracker.most_accurate_team('20142015')).to eq('Toronto FC')
     end
   end
 
   describe '#least_accurate_team' do
     it 'returns the team with the worst ratio of shots to goals' do
-      expect(@stat_tracker.least_accurate_team('20122013')).to eq('Houston Dynamo')
-      expect(@stat_tracker.least_accurate_team('20142015')).to eq('New England Revolution')
+      expect(@stat_tracker.least_accurate_team('20122013')).to eq('New York City FC')
+      expect(@stat_tracker.least_accurate_team('20142015')).to eq('Columbus Crew SC')
     end
   end
 


### PR DESCRIPTION
This PR adds the fewest tackles and most tackles methods and their tests. A tackles by team helper method and test were also added. I also noticed that the most and least accurate methods were returning ties, so I added more decimal places to the accuracy helper method.